### PR TITLE
fix(android): Prevent ArrayIndexOutOfBoundsException in permission check

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
@@ -130,7 +130,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
               val callbackActivity = args[1] as PermissionAwareActivity
               for (j in permissionsToCheck.indices) {
                 val permission = permissionsToCheck[j]
-                if (results.size > 0 && results[j] == PackageManager.PERMISSION_GRANTED) {
+                if (results.size > j && results[j] == PackageManager.PERMISSION_GRANTED) {
                   grantedPermissions.putString(permission, GRANTED)
                 } else {
                   if (callbackActivity.shouldShowRequestPermissionRationale(permission)) {


### PR DESCRIPTION
## Summary:

This PR addresses a potential `ArrayIndexOutOfBoundsException` in the Android module's permission checking logic.

```diff
- results.length > 0 && results[j] == PackageManager.PERMISSION_GRANTED
+ results.length > j && results[j] == PackageManager.PERMISSION_GRANTED
```

It ensures that we only access the results array when the index `j` is within bounds, preventing crashes due to invalid array access that have been occurring in the production environment.

Here is the Crashlytics dashboard concerning this type of crash on my app last week (react-native 0.75.4 - old arch):
![image](https://github.com/user-attachments/assets/0b7c1a10-39f6-4a17-9eee-4b17986f5b85)


## Changelog:

[ANDROID] [FIXED] - Prevent ArrayIndexOutOfBoundsException in permission check